### PR TITLE
docs: clean up and bump v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 Minimal vite plugin for environment isolation via macros for client-only and server-only code.
 
-## Installation
+## Install
 
 ```sh
 npm install -D vite-env-only
+
 ```
+
+## Setup
 
 ```ts
 // vite.config.ts
@@ -28,6 +31,8 @@ declare const serverOnly$: <T>(_: T) => T | undefined
 
 Marks an expression as server-only and replaces it with `undefined` on the client.
 Keeps the expression as-is on the server.
+
+For example:
 
 ```ts
 import { serverOnly$ } from "vite-env-only"
@@ -56,6 +61,8 @@ declare const clientOnly$: <T>(_: T) => T | undefined
 Marks an expression as client-only and replaces it with `undefined` on the server.
 Keeps the expression as-is on the client.
 
+For example:
+
 ```ts
 import { clientOnly$ } from "vite-env-only"
 
@@ -77,6 +84,8 @@ export const message = "i only exist on the client"
 ## Dead-code elimination
 
 This plugin eliminates any identifiers that become unreferenced as a result of macro replacement.
+
+For example:
 
 ```ts
 import { serverOnly$, clientOnly$ } from "vite-env-only"
@@ -118,19 +127,20 @@ export const clientThing = clientOnly$(clientValue)
 ## Why?
 
 Vite already provides [`import.meta.env.SSR`][vite-env-vars] which works in a similar way to this plugin in production.
-However, in development Vite neither substitutes `import.meta.env.SSR` nor performs dead-code elimination as Vite considers these to be optimizations.
+However, in development Vite neither replaces `import.meta.env.SSR` nor performs dead-code elimination as Vite considers these steps to be optimizations.
 
 In general, its a bad idea to rely on optimizations for correctness.
-In contrast, this plugin considers substitution and dead-code elimination to be part of its feature set.
+In contrast, this plugin considers macro replacement and dead-code elimination to be part of its feature set.
 
 Additionally, this plugin uses function calls to mark expressions as server-only or client-only.
 That means it can _guarantee_ that code within its macros never ends up in the wrong environment while only transforming a single AST node type: function call expressions.
 
-`import.meta.env.SSR` is instead a special identifier which can show up in many different AST node types: `if` statements, ternaries, `switch` statements, etc. which makes it easy to miss edge cases during dead-code elimination.
+`import.meta.env.SSR` is instead a special identifier which can show up in many different AST node types: `if` statements, ternaries, `switch` statements, etc.
+This makes it far more challenging to guarantee that dead-code completely eliminated.
 
 ## Prior art
 
-Thanks to these project for exploring environment isolation and transpilation conventions:
+Thanks to these project for exploring environment isolation and conventions for transpilation:
 
 - [`esm-env`][esm-env]
 - [Qwik][qwik]


### PR DESCRIPTION
Mistakenly thought that adding `!` to commit prefix would trigger a major release.
Instead, it causes semantic-release to ignore those commits when considering a version bump.
See https://github.com/semantic-release/semantic-release/issues/2339

BREAKING CHANGE:
- Rename macros (`server$` -> `serverOnly$`, `client$` -> `clientOnly$`)
- Only eliminate identifiers that have become unreferenced as a result of macro replacement