### PR TITLE
ci: run build against PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,20 @@ jobs:
       - uses: pnpm/action-setup@v2
       - run: pnpm install
       - run: pnpm test
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - uses: pnpm/action-setup@v2
+      - run: pnpm install
+      - run: pnpm build
   Release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [Typecheck, Test]
+    needs: [Typecheck, Test, Build]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
We're currently only building in CI as part of the release workflow, so this change ensures that PRs can build successfully before being merged. This PR will fail the build since `main` is currently broken, but this ensures that subsequent PRs have to pass.