### PR TITLE
fix: add Vite to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "test": "vitest"
   },
   "packageManager": "pnpm@8.13.1",
+  "peerDependencies": {
+    "vite": "*"
+  },
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
     "@types/babel__generator": "^7.6.8",


### PR DESCRIPTION
This fixes the broken build which is due to the newly added usage of Vite's `normalizePath` util causing Vite to get bundled (which then fails for some reason, but we don't want to attempt it anyway) since it's only a dev dependency, and we don't want to pull in all of Vite as a direct dependency,

We alternatively could vendor the `normalizePath` logic or depend on a smaller package, but I think long term it's better for us to ensure we have access to all Vite APIs. I've opted to not be prescriptive about Vite versions since I'm not sure what our minimum version would be and I think it's better to support future Vite versions by default.