### PR TITLE
Use default import from micromatch to fix ESM build error

### DIFF
--- a/.changeset/poor-jars-notice.md
+++ b/.changeset/poor-jars-notice.md
@@ -1,0 +1,5 @@
+---
+"vite-env-only": patch
+---
+
+Use default import from micromatch to fix ESM build error

--- a/src/validate-id.ts
+++ b/src/validate-id.ts
@@ -1,4 +1,4 @@
-import { isMatch } from "micromatch"
+import micromatch from "micromatch"
 
 import { Env } from "./env"
 import pkg from "../package.json"
@@ -27,7 +27,7 @@ export function validateId({
 
   for (const pattern of patterns) {
     if (
-      (typeof pattern === "string" && isMatch(id, pattern)) ||
+      (typeof pattern === "string" && micromatch.isMatch(id, pattern)) ||
       (pattern instanceof RegExp && id.match(pattern))
     ) {
       let message = errorMessage({


### PR DESCRIPTION
Fixes https://github.com/pcattori/vite-env-only/issues/32