### PR TITLE
Add standalone feature plugins

### DIFF
--- a/.changeset/standalone-plugins.md
+++ b/.changeset/standalone-plugins.md
@@ -1,0 +1,5 @@
+---
+"vite-env-only": minor
+---
+
+Add standalone plugins for `macros`, `denyFiles` and `denyImports`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ export default defineConfig({
 })
 ```
 
+This feature is also available as a standalone plugin:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite"
+import envOnly from "vite-env-only"
+
+export default defineConfig({
+  plugins: [
+    envOnly.denyImports({
+      client: ["fs-extra", /^node:/],
+    }),
+  ],
+})
+```
+
 ### `denyFiles`
 
 Configures validation of files that should not be present on the client or server.
@@ -92,6 +108,22 @@ export default defineConfig({
           "src/secrets.ts",
         ],
       },
+    }),
+  ],
+})
+```
+
+This feature is also available as a standalone plugin:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite"
+import envOnly from "vite-env-only"
+
+export default defineConfig({
+  plugins: [
+    envOnly.denyFiles({
+      client: ["**/*.server.*"],
     }),
   ],
 })
@@ -204,6 +236,19 @@ import { serverOnly$ } from "vite-env-only"
 
 export const API_KEY = serverOnly$("secret")!
 //           ^? string
+```
+
+### Standalone plugin
+
+The macros feature is also available as a standalone plugin:
+
+```ts
+import { defineConfig } from "vite"
+import envOnly from "vite-env-only"
+
+export default defineConfig({
+  plugins: [envOnly.macros()],
+})
 ```
 
 ### Why?

--- a/test/macros/macros.test.ts
+++ b/test/macros/macros.test.ts
@@ -9,11 +9,14 @@ describe("macros", () => {
   const config = ({
     ssr,
     outDir,
+    plugins,
   }: {
     ssr: boolean
     outDir: string
+    plugins: vite.PluginOption[]
   }): vite.InlineConfig => ({
     root,
+    plugins,
     build: {
       ssr,
       minify: false,
@@ -28,12 +31,18 @@ describe("macros", () => {
         },
       },
     },
-    plugins: [envOnly()],
   })
 
   test("serverOnly$", async () => {
     const outDir = path.join(root, "dist/server")
-    await vite.build(config({ ssr: true, outDir }))
+
+    await vite.build(
+      config({
+        ssr: true,
+        outDir,
+        plugins: [envOnly()],
+      })
+    )
 
     expect((await import(outDir)).default).toEqual({
       server: true,
@@ -43,11 +52,35 @@ describe("macros", () => {
 
   test("clientOnly$", async () => {
     const outDir = path.join(root, "dist/client")
-    await vite.build(config({ ssr: false, outDir }))
+
+    await vite.build(
+      config({
+        ssr: false,
+        outDir,
+        plugins: [envOnly()],
+      })
+    )
 
     expect((await import(outDir)).default).toEqual({
       server: false,
       client: true,
+    })
+  })
+
+  test("standalone plugin", async () => {
+    const outDir = path.join(root, "dist/server")
+
+    await vite.build(
+      config({
+        ssr: true,
+        outDir,
+        plugins: [envOnly.macros()],
+      })
+    )
+
+    expect((await import(outDir)).default).toEqual({
+      server: true,
+      client: false,
     })
   })
 })


### PR DESCRIPTION
This PR exports each feature as its own plugin.

This is so frameworks like Remix/React Router can opt into a subset of the plugin's behaviour without inheriting defaults (including future defaults). Most notably this will allow React Router to use the `denyFiles` feature to implement `.server` modules without inadvertently adding support for macros.